### PR TITLE
Fix: use major version suffixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY := tun2socks
-MODULE := github.com/xjasonlyu/tun2socks
+MODULE := github.com/xjasonlyu/tun2socks/v2
 
 BUILD_DIR     := build
 BUILD_TAGS    :=

--- a/component/simple-obfs/http.go
+++ b/component/simple-obfs/http.go
@@ -9,7 +9,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/xjasonlyu/tun2socks/common/pool"
+	"github.com/xjasonlyu/tun2socks/v2/common/pool"
 )
 
 // HTTPObfs is shadowsocks http simple-obfs implementation

--- a/component/simple-obfs/tls.go
+++ b/component/simple-obfs/tls.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/xjasonlyu/tun2socks/common/pool"
+	"github.com/xjasonlyu/tun2socks/v2/common/pool"
 )
 
 func init() {

--- a/constant/metadata.go
+++ b/constant/metadata.go
@@ -7,7 +7,7 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/xjasonlyu/tun2socks/transport/socks5"
+	"github.com/xjasonlyu/tun2socks/v2/transport/socks5"
 )
 
 const (

--- a/core/device/fd/fd_unix.go
+++ b/core/device/fd/fd_unix.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/xjasonlyu/tun2socks/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
 )

--- a/core/device/fd/fd_windows.go
+++ b/core/device/fd/fd_windows.go
@@ -3,7 +3,7 @@ package fd
 import (
 	"errors"
 
-	"github.com/xjasonlyu/tun2socks/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
 )
 
 func Open(name string, mtu uint32) (device.Device, error) {

--- a/core/device/fd/open_linux.go
+++ b/core/device/fd/open_linux.go
@@ -3,7 +3,7 @@ package fd
 import (
 	"fmt"
 
-	"github.com/xjasonlyu/tun2socks/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
 	"gvisor.dev/gvisor/pkg/tcpip/link/fdbased"
 )
 

--- a/core/device/fd/open_others.go
+++ b/core/device/fd/open_others.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/xjasonlyu/tun2socks/core/device"
-	"github.com/xjasonlyu/tun2socks/core/device/rwbased"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device/rwbased"
 )
 
 func open(fd int, mtu uint32) (device.Device, error) {

--- a/core/device/tun/io_unix.go
+++ b/core/device/tun/io_unix.go
@@ -3,7 +3,7 @@
 package tun
 
 import (
-	"github.com/xjasonlyu/tun2socks/common/pool"
+	"github.com/xjasonlyu/tun2socks/v2/common/pool"
 )
 
 const (

--- a/core/device/tun/tun.go
+++ b/core/device/tun/tun.go
@@ -2,7 +2,7 @@
 package tun
 
 import (
-	"github.com/xjasonlyu/tun2socks/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
 )
 
 const Driver = "tun"

--- a/core/device/tun/tun_gvisor.go
+++ b/core/device/tun/tun_gvisor.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/xjasonlyu/tun2socks/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
 
 	"golang.org/x/sys/unix"
 	"gvisor.dev/gvisor/pkg/tcpip/link/fdbased"

--- a/core/device/tun/tun_wireguard.go
+++ b/core/device/tun/tun_wireguard.go
@@ -5,8 +5,8 @@ package tun
 import (
 	"fmt"
 
-	"github.com/xjasonlyu/tun2socks/core/device"
-	"github.com/xjasonlyu/tun2socks/core/device/rwbased"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device/rwbased"
 
 	"golang.zx2c4.com/wireguard/tun"
 )

--- a/core/stack/stack.go
+++ b/core/stack/stack.go
@@ -2,7 +2,7 @@
 package stack
 
 import (
-	"github.com/xjasonlyu/tun2socks/core"
+	"github.com/xjasonlyu/tun2socks/v2/core"
 
 	"gvisor.dev/gvisor/pkg/tcpip"
 	"gvisor.dev/gvisor/pkg/tcpip/network/ipv4"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"os"
 
-	"github.com/xjasonlyu/tun2socks/component/dialer"
-	"github.com/xjasonlyu/tun2socks/core/device"
-	"github.com/xjasonlyu/tun2socks/core/stack"
-	"github.com/xjasonlyu/tun2socks/log"
-	"github.com/xjasonlyu/tun2socks/proxy"
-	"github.com/xjasonlyu/tun2socks/stats"
-	"github.com/xjasonlyu/tun2socks/tunnel"
+	"github.com/xjasonlyu/tun2socks/v2/component/dialer"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/stack"
+	"github.com/xjasonlyu/tun2socks/v2/log"
+	"github.com/xjasonlyu/tun2socks/v2/proxy"
+	"github.com/xjasonlyu/tun2socks/v2/stats"
+	"github.com/xjasonlyu/tun2socks/v2/tunnel"
 
 	"gopkg.in/yaml.v3"
 )

--- a/engine/parse.go
+++ b/engine/parse.go
@@ -6,11 +6,11 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/xjasonlyu/tun2socks/core/device"
-	"github.com/xjasonlyu/tun2socks/core/device/fd"
-	"github.com/xjasonlyu/tun2socks/core/device/tun"
-	"github.com/xjasonlyu/tun2socks/proxy"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device/fd"
+	"github.com/xjasonlyu/tun2socks/v2/core/device/tun"
+	"github.com/xjasonlyu/tun2socks/v2/proxy"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
 )
 
 func parseDevice(s string, mtu uint32) (device.Device, error) {

--- a/engine/tunnel.go
+++ b/engine/tunnel.go
@@ -1,8 +1,8 @@
 package engine
 
 import (
-	"github.com/xjasonlyu/tun2socks/core"
-	"github.com/xjasonlyu/tun2socks/tunnel"
+	"github.com/xjasonlyu/tun2socks/v2/core"
+	"github.com/xjasonlyu/tun2socks/v2/tunnel"
 )
 
 var _ core.Handler = (*fakeTunnel)(nil)

--- a/engine/version.go
+++ b/engine/version.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"strings"
 
-	V "github.com/xjasonlyu/tun2socks/constant"
+	V "github.com/xjasonlyu/tun2socks/v2/constant"
 )
 
 func showVersion() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/xjasonlyu/tun2socks
+module github.com/xjasonlyu/tun2socks/v2
 
 go 1.17
 

--- a/log/event.go
+++ b/log/event.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/xjasonlyu/tun2socks/common/observable"
+	"github.com/xjasonlyu/tun2socks/v2/common/observable"
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -6,8 +6,8 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/xjasonlyu/tun2socks/engine"
-	"github.com/xjasonlyu/tun2socks/log"
+	"github.com/xjasonlyu/tun2socks/v2/engine"
+	"github.com/xjasonlyu/tun2socks/v2/log"
 )
 
 var key = new(engine.Key)

--- a/proxy/base.go
+++ b/proxy/base.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"net"
 
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
 )
 
 var _ Proxy = (*Base)(nil)

--- a/proxy/direct.go
+++ b/proxy/direct.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net"
 
-	"github.com/xjasonlyu/tun2socks/component/dialer"
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
+	"github.com/xjasonlyu/tun2socks/v2/component/dialer"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
 )
 
 var _ Proxy = (*Direct)(nil)

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -13,9 +13,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/xjasonlyu/tun2socks/component/dialer"
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
+	"github.com/xjasonlyu/tun2socks/v2/component/dialer"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
 )
 
 type HTTP struct {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"time"
 
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
 )
 
 const (

--- a/proxy/reject.go
+++ b/proxy/reject.go
@@ -6,8 +6,8 @@ import (
 	"net"
 	"time"
 
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
 )
 
 var _ Proxy = (*Reject)(nil)

--- a/proxy/shadowsocks.go
+++ b/proxy/shadowsocks.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/xjasonlyu/tun2socks/component/dialer"
-	obfs "github.com/xjasonlyu/tun2socks/component/simple-obfs"
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
-	"github.com/xjasonlyu/tun2socks/transport/socks5"
+	"github.com/xjasonlyu/tun2socks/v2/component/dialer"
+	obfs "github.com/xjasonlyu/tun2socks/v2/component/simple-obfs"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
+	"github.com/xjasonlyu/tun2socks/v2/transport/socks5"
 
 	"github.com/Dreamacro/go-shadowsocks2/core"
 )

--- a/proxy/socks4.go
+++ b/proxy/socks4.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/xjasonlyu/tun2socks/component/dialer"
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
-	"github.com/xjasonlyu/tun2socks/transport/socks4"
+	"github.com/xjasonlyu/tun2socks/v2/component/dialer"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
+	"github.com/xjasonlyu/tun2socks/v2/transport/socks4"
 )
 
 var _ Proxy = (*Socks4)(nil)

--- a/proxy/socks5.go
+++ b/proxy/socks5.go
@@ -7,10 +7,10 @@ import (
 	"io"
 	"net"
 
-	"github.com/xjasonlyu/tun2socks/component/dialer"
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/proxy/proto"
-	"github.com/xjasonlyu/tun2socks/transport/socks5"
+	"github.com/xjasonlyu/tun2socks/v2/component/dialer"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
+	"github.com/xjasonlyu/tun2socks/v2/transport/socks5"
 )
 
 var _ Proxy = (*Socks5)(nil)

--- a/stats/connections.go
+++ b/stats/connections.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/xjasonlyu/tun2socks/tunnel/statistic"
+	"github.com/xjasonlyu/tun2socks/v2/tunnel/statistic"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"

--- a/stats/server.go
+++ b/stats/server.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"time"
 
-	V "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/log"
-	"github.com/xjasonlyu/tun2socks/tunnel/statistic"
+	V "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/log"
+	"github.com/xjasonlyu/tun2socks/v2/tunnel/statistic"
 
 	"github.com/go-chi/chi"
 	"github.com/go-chi/cors"

--- a/tunnel/statistic/tracker.go
+++ b/tunnel/statistic/tracker.go
@@ -4,7 +4,7 @@ import (
 	"net"
 	"time"
 
-	M "github.com/xjasonlyu/tun2socks/constant"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
 
 	"github.com/gofrs/uuid"
 	"go.uber.org/atomic"

--- a/tunnel/tcp.go
+++ b/tunnel/tcp.go
@@ -6,12 +6,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/xjasonlyu/tun2socks/common/pool"
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/core"
-	"github.com/xjasonlyu/tun2socks/log"
-	"github.com/xjasonlyu/tun2socks/proxy"
-	"github.com/xjasonlyu/tun2socks/tunnel/statistic"
+	"github.com/xjasonlyu/tun2socks/v2/common/pool"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/core"
+	"github.com/xjasonlyu/tun2socks/v2/log"
+	"github.com/xjasonlyu/tun2socks/v2/proxy"
+	"github.com/xjasonlyu/tun2socks/v2/tunnel/statistic"
 )
 
 const (

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -3,8 +3,8 @@ package tunnel
 import (
 	"runtime"
 
-	"github.com/xjasonlyu/tun2socks/core"
-	"github.com/xjasonlyu/tun2socks/log"
+	"github.com/xjasonlyu/tun2socks/v2/core"
+	"github.com/xjasonlyu/tun2socks/v2/log"
 )
 
 const (

--- a/tunnel/udp.go
+++ b/tunnel/udp.go
@@ -6,13 +6,13 @@ import (
 	"os"
 	"time"
 
-	"github.com/xjasonlyu/tun2socks/common/pool"
-	"github.com/xjasonlyu/tun2socks/component/nat"
-	M "github.com/xjasonlyu/tun2socks/constant"
-	"github.com/xjasonlyu/tun2socks/core"
-	"github.com/xjasonlyu/tun2socks/log"
-	"github.com/xjasonlyu/tun2socks/proxy"
-	"github.com/xjasonlyu/tun2socks/tunnel/statistic"
+	"github.com/xjasonlyu/tun2socks/v2/common/pool"
+	"github.com/xjasonlyu/tun2socks/v2/component/nat"
+	M "github.com/xjasonlyu/tun2socks/v2/constant"
+	"github.com/xjasonlyu/tun2socks/v2/core"
+	"github.com/xjasonlyu/tun2socks/v2/log"
+	"github.com/xjasonlyu/tun2socks/v2/proxy"
+	"github.com/xjasonlyu/tun2socks/v2/tunnel/statistic"
 )
 
 var (


### PR DESCRIPTION
According to the [go module convention](https://go.dev/ref/mod#module-path), `if the module is released at major version 2 or higher, the module path must end with a major version suffix like /v2. This may or may not be part of the subdirectory name`.

Therefore currently the v2 version of this repo can neither be fetched via `go get` command nor be referred in `go.mod`:

```bash
$ go get github.com/xjasonlyu/tun2socks      # without version will only fetch v1 code
go get: added github.com/xjasonlyu/tun2socks v1.18.3

$ go get github.com/xjasonlyu/tun2socks@v2.3.2      # specify v2 version will cause error
go get: github.com/xjasonlyu/tun2socks@v2.3.2: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2
```

To demonstrate the effect, I had made a quick fork and put a `v2.3.2-fix` to my repo, and below command would work as expected:

```bash
$ go get github.com/linfan/tun2socks/v2@v2.3.2-fix       # it works
```

