### PR TITLE
Feature: support setSocketOptions on windows

### DIFF
--- a/component/dialer/sockopt_others.go
+++ b/component/dialer/sockopt_others.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin
+//go:build !linux && !darwin && !windows
 
 package dialer
 

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -9,7 +9,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-const IP_UNICAST_IF = 31
+const (
+	IP_UNICAST_IF   = 31
+	IPV6_UNICAST_IF = 31
+)
 
 func setSocketOptions(network, address string, c syscall.RawConn, opts *Options) (err error) {
 	if opts == nil || !isTCPSocket(network) && !isUDPSocket(network) {
@@ -62,5 +65,5 @@ func bindSocketToInterface4(handle windows.Handle, interfaceIndex uint32) error 
 }
 
 func bindSocketToInterface6(handle windows.Handle, interfaceIndex uint32) error {
-	return windows.SetsockoptInt(handle, windows.IPPROTO_IPV6, IP_UNICAST_IF, int(interfaceIndex))
+	return windows.SetsockoptInt(handle, windows.IPPROTO_IPV6, IPV6_UNICAST_IF, int(interfaceIndex))
 }

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -9,6 +9,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+const IP_UNICAST_IF = 31
+
 func setSocketOptions(network, address string, c syscall.RawConn, opts *Options) (err error) {
 	if opts == nil || !isTCPSocket(network) && !isUDPSocket(network) {
 		return
@@ -50,8 +52,9 @@ func setSocketOptions(network, address string, c syscall.RawConn, opts *Options)
 }
 
 func bindSocketToInterface4(handle windows.Handle, interfaceIndex uint32) error {
-	const IP_UNICAST_IF = 31
-	/* MSDN says for IPv4 this needs to be in net byte order, so that it's like an IP address with leading zeros. */
+	// For IPv4, this parameter must be an interface index in network byte order.
+	//
+	// Ref: https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 	var bytes [4]byte
 	binary.BigEndian.PutUint32(bytes[:], interfaceIndex)
 	interfaceIndex = *(*uint32)(unsafe.Pointer(&bytes[0]))
@@ -59,6 +62,5 @@ func bindSocketToInterface4(handle windows.Handle, interfaceIndex uint32) error 
 }
 
 func bindSocketToInterface6(handle windows.Handle, interfaceIndex uint32) error {
-	const IPV6_UNICAST_IF = 31
-	return windows.SetsockoptInt(handle, windows.IPPROTO_IPV6, IPV6_UNICAST_IF, int(interfaceIndex))
+	return windows.SetsockoptInt(handle, windows.IPPROTO_IPV6, IP_UNICAST_IF, int(interfaceIndex))
 }

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -17,7 +17,8 @@ func setSocketOptions(network, address string, c syscall.RawConn, opts *Options)
 	var innerErr error
 	err = c.Control(func(fd uintptr) {
 		host, _, _ := net.SplitHostPort(address)
-		if ip := net.ParseIP(host); ip != nil && !ip.IsGlobalUnicast() {
+		ip := net.ParseIP(host)
+		if ip != nil && !ip.IsGlobalUnicast() {
 			return
 		}
 
@@ -33,7 +34,7 @@ func setSocketOptions(network, address string, c syscall.RawConn, opts *Options)
 				innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))
 			case "tcp6", "udp6":
 				innerErr = bindSocketToInterface6(windows.Handle(fd), uint32(opts.InterfaceIndex))
-				if network == "udp6" {
+				if network == "udp6" && ip.To16() == nil {
 					// the underlying IP net maybe IPv4 even if the 'network' param is 'udp6',
 					// so we should bind socket to interface4 at the same time
 					innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -41,7 +41,7 @@ func setSocketOptions(network, address string, c syscall.RawConn, opts *Options)
 				innerErr = bindSocketToInterface6(windows.Handle(fd), uint32(opts.InterfaceIndex))
 				if network == "udp6" && ip == nil {
 					// The underlying IP net maybe IPv4 even if the `network` param is `udp6`,
-					// so we should bind socket to interface4 at the same time
+					// so we should bind socket to interface4 at the same time.
 					innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))
 				}
 			}
@@ -63,6 +63,6 @@ func bindSocketToInterface4(handle windows.Handle, index uint32) error {
 	return windows.SetsockoptInt(handle, windows.IPPROTO_IP, IP_UNICAST_IF, int(index))
 }
 
-func bindSocketToInterface6(handle windows.Handle, interfaceIndex uint32) error {
-	return windows.SetsockoptInt(handle, windows.IPPROTO_IPV6, IPV6_UNICAST_IF, int(interfaceIndex))
+func bindSocketToInterface6(handle windows.Handle, index uint32) error {
+	return windows.SetsockoptInt(handle, windows.IPPROTO_IPV6, IPV6_UNICAST_IF, int(index))
 }

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -40,7 +40,7 @@ func setSocketOptions(network, address string, c syscall.RawConn, opts *Options)
 			case "tcp6", "udp6":
 				innerErr = bindSocketToInterface6(windows.Handle(fd), uint32(opts.InterfaceIndex))
 				if network == "udp6" && ip == nil {
-					// the underlying IP net maybe IPv4 even if the 'network' param is 'udp6',
+					// The underlying IP net maybe IPv4 even if the `network` param is `udp6`,
 					// so we should bind socket to interface4 at the same time
 					innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))
 				}
@@ -54,14 +54,13 @@ func setSocketOptions(network, address string, c syscall.RawConn, opts *Options)
 	return
 }
 
-func bindSocketToInterface4(handle windows.Handle, interfaceIndex uint32) error {
+func bindSocketToInterface4(handle windows.Handle, index uint32) error {
 	// For IPv4, this parameter must be an interface index in network byte order.
-	//
 	// Ref: https://learn.microsoft.com/en-us/windows/win32/winsock/ipproto-ip-socket-options
 	var bytes [4]byte
-	binary.BigEndian.PutUint32(bytes[:], interfaceIndex)
-	interfaceIndex = *(*uint32)(unsafe.Pointer(&bytes[0]))
-	return windows.SetsockoptInt(handle, windows.IPPROTO_IP, IP_UNICAST_IF, int(interfaceIndex))
+	binary.BigEndian.PutUint32(bytes[:], index)
+	index = *(*uint32)(unsafe.Pointer(&bytes[0]))
+	return windows.SetsockoptInt(handle, windows.IPPROTO_IP, IP_UNICAST_IF, int(index))
 }
 
 func bindSocketToInterface6(handle windows.Handle, interfaceIndex uint32) error {

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -34,7 +34,7 @@ func setSocketOptions(network, address string, c syscall.RawConn, opts *Options)
 				innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))
 			case "tcp6", "udp6":
 				innerErr = bindSocketToInterface6(windows.Handle(fd), uint32(opts.InterfaceIndex))
-				if network == "udp6" && ip.To16() == nil {
+				if network == "udp6" && ip == nil {
 					// the underlying IP net maybe IPv4 even if the 'network' param is 'udp6',
 					// so we should bind socket to interface4 at the same time
 					innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -1,0 +1,56 @@
+package dialer
+
+import (
+	"encoding/binary"
+	"net"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func setSocketOptions(network, address string, c syscall.RawConn, opts *Options) (err error) {
+	if opts == nil || !isTCPSocket(network) && !isUDPSocket(network) {
+		return
+	}
+
+	var innerErr error
+	err = c.Control(func(fd uintptr) {
+		host, _, _ := net.SplitHostPort(address)
+		ip := net.ParseIP(host)
+		if ip != nil && !ip.IsGlobalUnicast() {
+			return
+		}
+
+		if opts.InterfaceName != "" {
+			if len(ip) == net.IPv6len {
+				innerErr = bindSocketToInterface6(windows.Handle(fd), uint32(opts.InterfaceIndex))
+			} else {
+				innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))
+			}
+		}
+	})
+
+	if innerErr != nil {
+		err = innerErr
+	}
+	return
+}
+
+func bindSocketToInterface4(handle windows.Handle, interfaceIndex uint32) error {
+	const IP_UNICAST_IF = 31
+	/* MSDN says for IPv4 this needs to be in net byte order, so that it's like an IP address with leading zeros. */
+	var bytes [4]byte
+	binary.BigEndian.PutUint32(bytes[:], interfaceIndex)
+	interfaceIndex = *(*uint32)(unsafe.Pointer(&bytes[0]))
+	err := windows.SetsockoptInt(handle, windows.IPPROTO_IP, IP_UNICAST_IF, int(interfaceIndex))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func bindSocketToInterface6(handle windows.Handle, interfaceIndex uint32) error {
+	const IPV6_UNICAST_IF = 31
+	return windows.SetsockoptInt(handle, windows.IPPROTO_IPV6, IPV6_UNICAST_IF, int(interfaceIndex))
+}

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -33,6 +33,11 @@ func setSocketOptions(network, address string, c syscall.RawConn, opts *Options)
 				innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))
 			case "tcp6", "udp6":
 				innerErr = bindSocketToInterface6(windows.Handle(fd), uint32(opts.InterfaceIndex))
+				if network == "udp6" {
+					// the underlying IP net maybe IPv4 even if the 'network' param is 'udp6',
+					// so we should bind socket to interface4 at the same time
+					innerErr = bindSocketToInterface4(windows.Handle(fd), uint32(opts.InterfaceIndex))
+				}
 			}
 		}
 	})

--- a/component/dialer/sockopt_windows.go
+++ b/component/dialer/sockopt_windows.go
@@ -55,11 +55,7 @@ func bindSocketToInterface4(handle windows.Handle, interfaceIndex uint32) error 
 	var bytes [4]byte
 	binary.BigEndian.PutUint32(bytes[:], interfaceIndex)
 	interfaceIndex = *(*uint32)(unsafe.Pointer(&bytes[0]))
-	err := windows.SetsockoptInt(handle, windows.IPPROTO_IP, IP_UNICAST_IF, int(interfaceIndex))
-	if err != nil {
-		return err
-	}
-	return nil
+	return windows.SetsockoptInt(handle, windows.IPPROTO_IP, IP_UNICAST_IF, int(interfaceIndex))
 }
 
 func bindSocketToInterface6(handle windows.Handle, interfaceIndex uint32) error {


### PR DESCRIPTION
Hi, I have made a PR for supporting setSocketOptions on windows, since it is not supported now. 

The idea is taken from [wireguard-go](https://github.com/WireGuard/wireguard-go/blob/bb719d3a6e2cd20ec00f26d65c0073c1dde6b529/conn/bind_windows.go#L566)