### PR TITLE
Add tun post script

### DIFF
--- a/engine/key.go
+++ b/engine/key.go
@@ -13,5 +13,7 @@ type Key struct {
 	TCPModerateReceiveBuffer bool          `yaml:"tcp-moderate-receive-buffer"`
 	TCPSendBufferSize        string        `yaml:"tcp-send-buffer-size"`
 	TCPReceiveBufferSize     string        `yaml:"tcp-receive-buffer-size"`
+	TunPreUp                 string        `yaml:"tun-preup"`
+	TunPostUp                string        `yaml:"tun-postup"`
 	UDPTimeout               time.Duration `yaml:"udp-timeout"`
 }

--- a/engine/key.go
+++ b/engine/key.go
@@ -13,7 +13,7 @@ type Key struct {
 	TCPModerateReceiveBuffer bool          `yaml:"tcp-moderate-receive-buffer"`
 	TCPSendBufferSize        string        `yaml:"tcp-send-buffer-size"`
 	TCPReceiveBufferSize     string        `yaml:"tcp-receive-buffer-size"`
-	TunPreUp                 string        `yaml:"tun-preup"`
-	TunPostUp                string        `yaml:"tun-postup"`
+	TUNPreUp                 string        `yaml:"tun-pre-up"`
+	TUNPostUp                string        `yaml:"tun-post-up"`
 	UDPTimeout               time.Duration `yaml:"udp-timeout"`
 }

--- a/main.go
+++ b/main.go
@@ -36,8 +36,8 @@ func init() {
 	flag.StringVar(&key.TCPSendBufferSize, "tcp-sndbuf", "", "Set TCP send buffer size for netstack")
 	flag.StringVar(&key.TCPReceiveBufferSize, "tcp-rcvbuf", "", "Set TCP receive buffer size for netstack")
 	flag.BoolVar(&key.TCPModerateReceiveBuffer, "tcp-auto-tuning", false, "Enable TCP receive buffer auto-tuning")
-	flag.StringVar(&key.TunPreUp, "preup", "", "Tun device pre-setup script")
-	flag.StringVar(&key.TunPostUp, "postup", "", "Tun device post-setup script")
+	flag.StringVar(&key.TUNPreUp, "tun-pre-up", "", "Execute a command before TUN device setup")
+	flag.StringVar(&key.TUNPostUp, "tun-post-up", "", "Execute a command after TUN device setup")
 	flag.BoolVar(&versionFlag, "version", false, "Show version and then quit")
 	flag.Parse()
 }

--- a/main.go
+++ b/main.go
@@ -36,6 +36,8 @@ func init() {
 	flag.StringVar(&key.TCPSendBufferSize, "tcp-sndbuf", "", "Set TCP send buffer size for netstack")
 	flag.StringVar(&key.TCPReceiveBufferSize, "tcp-rcvbuf", "", "Set TCP receive buffer size for netstack")
 	flag.BoolVar(&key.TCPModerateReceiveBuffer, "tcp-auto-tuning", false, "Enable TCP receive buffer auto-tuning")
+	flag.StringVar(&key.TunPreUp, "preup", "", "Tun device pre-setup script")
+	flag.StringVar(&key.TunPostUp, "postup", "", "Tun device post-setup script")
 	flag.BoolVar(&versionFlag, "version", false, "Show version and then quit")
 	flag.Parse()
 }


### PR DESCRIPTION
用于在 tun 设备创建后，执行一个自定义的脚本，比如
```
tun2socks -device tun3 -proxy socks5://127.0.0.1:1080 -postup "/bin/sh /root/proxy/route.sh"
```
route.sh 内容如:
```
# 配置 tun3 的 IP
ip addr add 172.16.8.1/24 dev tun3
ip link set dev tun3 up

# 添加代理服务地址直接通过 pppoe-WAN 路由
route add -host xxx.xxx.xxx.xxx dev pppoe-WAN

# 一些需要通过 tun3 代理的 ip 段...
route add -net 103.235.0.0/16 gw 172.16.8.1
route add -net 117.168.0.0/16 gw 172.16.8.1
route add -net 117.18.0.0/16 gw 172.16.8.1
route add -net 149.154.0.0/16 gw 172.16.8.1
route add -net 185.199.0.0/16 gw 172.16.8.1
```

有了 postup 这个参数，这样用便于做一些 tun 创建之后相关的自己的脚本设定。


