### PR TITLE
Feature: log support setting output

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"io"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,10 @@ var _defaultLevel = atomic.NewUint32(uint32(InfoLevel))
 func init() {
 	logrus.SetOutput(os.Stdout)
 	logrus.SetLevel(logrus.DebugLevel)
+}
+
+func SetOutput(out io.Writer) {
+	logrus.SetOutput(out)
 }
 
 func SetLevel(level Level) {


### PR DESCRIPTION
tun2socks 的 Log 库暴露 SetOutput 方法，这样可以在调用 tun2socks 时将日志重定向到其他位置，如本地文件。