### PR TITLE
Fixed panic when unassigned reply code arrives.

### DIFF
--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -72,7 +72,7 @@ func (r Reply) String() string {
 	case 0x08:
 		return "address type not supported"
 	default:
-		return fmt.Sprintf("unassigned <%#02x>", r)
+		return fmt.Sprintf("unassigned <%#02x>", uint8(r))
 	}
 }
 


### PR DESCRIPTION
When an unassigned reply code arrives, the `fmt.Sprintf` function tries to recursively go through the `String()` method and the application crashes due to a `goroutine stack exceeds 1000000000-byte limit`.

```
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0x140213043a0 stack=[0x14021304000, 0x14041304000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x100fc7266?, 0x1013edda0?})
	runtime/panic.go:1047 +0x40 fp=0x16f816d20 sp=0x16f816cf0 pc=0x100ca5ed0
runtime.newstack()
	runtime/stack.go:1105 +0x460 fp=0x16f816ed0 sp=0x16f816d20 pc=0x100cbf310
runtime.morestack()
	runtime/asm_arm64.s:316 +0x70 fp=0x16f816ed0 sp=0x16f816ed0 pc=0x100cd4a30

goroutine 62922 [running]:
runtime.deductAssistCredit(0xd0?)
	runtime/malloc.go:1201 +0x7c fp=0x140213043a0 sp=0x140213043a0 pc=0x100c7fd0c
runtime.mallocgc(0xd0, 0x10114b820, 0x1)
	runtime/malloc.go:932 +0xe4 fp=0x14021304410 sp=0x140213043a0 pc=0x100c7f4f4
runtime.newobject(0x9?)
	runtime/malloc.go:1254 +0x2c fp=0x14021304440 sp=0x14021304410 pc=0x100c7fdec
fmt.glob..func1()
	fmt/print.go:147 +0x24 fp=0x14021304470 sp=0x14021304440 pc=0x100d27ed4
sync.(*Pool).Get(0x101417c00)
	sync/pool.go:151 +0xc0 fp=0x140213044b0 sp=0x14021304470 pc=0x100cec550
fmt.newPrinter()
	fmt/print.go:152 +0x24 fp=0x140213044e0 sp=0x140213044b0 pc=0x100d27f24
fmt.Sprintf({0x100fc91e4, 0x12}, {0x14021304578, 0x1, 0x1})
	fmt/print.go:238 +0x30 fp=0x14021304540 sp=0x140213044e0 pc=0x100d284a0
github.com/xjasonlyu/tun2socks/v2/transport/socks5.Reply.String(0x1?)
	github.com/xjasonlyu/tun2socks/v2/transport/socks5/socks5.go:75 +0x14c fp=0x14021304590 sp=0x14021304540 pc=0x100f989ac
github.com/xjasonlyu/tun2socks/v2/transport/socks5.(*Reply).String(0x0?)
	<autogenerated>:1 +0x2c fp=0x140213045b0 sp=0x14021304590 pc=0x100f9a69c
fmt.(*pp).handleMethods(0x140066c3790, 0x15f45b8?)
	fmt/print.go:673 +0x21c fp=0x14021304810 sp=0x140213045b0 pc=0x100d2acfc
fmt.(*pp).printArg(0x140066c3790, {0x1010cd5e0?, 0x1013f79f0}, 0x78)
	fmt/print.go:756 +0x67c fp=0x140213048b0 sp=0x14021304810 pc=0x100d2b7ac
fmt.(*pp).doPrintf(0x140066c3790, {0x100fc91e4, 0x12}, {0x14021304a58?, 0x1, 0x1})
	fmt/print.go:1176 +0x850 fp=0x140213049c0 sp=0x140213048b0 pc=0x100d2e660
fmt.Sprintf({0x100fc91e4, 0x12}, {0x14021304a58, 0x1, 0x1})
	fmt/print.go:239 +0x4c fp=0x14021304a20 sp=0x140213049c0 pc=0x100d284bc
github.com/xjasonlyu/tun2socks/v2/transport/socks5.Reply.String(0x1?)
	github.com/xjasonlyu/tun2socks/v2/transport/socks5/socks5.go:75 +0x14c fp=0x14021304a70 sp=0x14021304a20 pc=0x100f989ac
github.com/xjasonlyu/tun2socks/v2/transport/socks5.(*Reply).String(0x0?)
	<autogenerated>:1 +0x2c fp=0x14021304a90 sp=0x14021304a70 pc=0x100f9a69c
fmt.(*pp).handleMethods(0x140066c36c0, 0x15f45b8?)
	fmt/print.go:673 +0x21c fp=0x14021304cf0 sp=0x14021304a90 pc=0x100d2acfc
fmt.(*pp).printArg(0x140066c36c0, {0x1010cd5e0?, 0x1013f79f0}, 0x78)
	fmt/print.go:756 +0x67c fp=0x14021304d90 sp=0x14021304cf0 pc=0x100d2b7ac
fmt.(*pp).doPrintf(0x140066c36c0, {0x100fc91e4, 0x12}, {0x14021304f38?, 0x1, 0x1})
	fmt/print.go:1176 +0x850 fp=0x14021304ea0 sp=0x14021304d90 pc=0x100d2e660
fmt.Sprintf({0x100fc91e4, 0x12}, {0x14021304f38, 0x1, 0x1})
	fmt/print.go:239 +0x4c fp=0x14021304f00 sp=0x14021304ea0 pc=0x100d284bc
github.com/xjasonlyu/tun2socks/v2/transport/socks5.Reply.String(0x1?)
	github.com/xjasonlyu/tun2socks/v2/transport/socks5/socks5.go:75 +0x14c fp=0x14021304f50 sp=0x14021304f00 pc=0x100f989ac
github.com/xjasonlyu/tun2socks/v2/transport/socks5.(*Reply).String(0x0?)
	<autogenerated>:1 +0x2c fp=0x14021304f70 sp=0x14021304f50 pc=0x100f9a69c
fmt.(*pp).handleMethods(0x140066c35f0, 0x15f45b8?)
	fmt/print.go:673 +0x21c fp=0x140213051d0 sp=0x14021304f70 pc=0x100d2acfc
fmt.(*pp).printArg(0x140066c35f0, {0x1010cd5e0?, 0x1013f79f0}, 0x78)
	fmt/print.go:756 +0x67c fp=0x14021305270 sp=0x140213051d0 pc=0x100d2b7ac
fmt.(*pp).doPrintf(0x140066c35f0, {0x100fc91e4, 0x12}, {0x14021305418?, 0x1, 0x1})
	fmt/print.go:1176 +0x850 fp=0x14021305380 sp=0x14021305270 pc=0x100d2e660
fmt.Sprintf({0x100fc91e4, 0x12}, {0x14021305418, 0x1, 0x1})
	fmt/print.go:239 +0x4c fp=0x140213053e0 sp=0x14021305380 pc=0x100d284bc
github.com/xjasonlyu/tun2socks/v2/transport/socks5.Reply.String(0x1?)
	github.com/xjasonlyu/tun2socks/v2/transport/socks5/socks5.go:75 +0x14c fp=0x14021305430 sp=0x140213053e0 pc=0x100f989ac
github.com/xjasonlyu/tun2socks/v2/transport/socks5.(*Reply).String(0x0?)
	<autogenerated>:1 +0x2c fp=0x14021305450 sp=0x14021305430 pc=0x100f9a69c
fmt.(*pp).handleMethods(0x140066c3520, 0x15f45b8?)
...
> There are a lot of the same strings, because the `String()` method is called recursively.
```