### PR TITLE
feature: device add support unixsocket use fd

### DIFF
--- a/core/device/unixbase/open_linux.go
+++ b/core/device/unixbase/open_linux.go
@@ -1,0 +1,24 @@
+package unixbase
+
+import (
+	"fmt"
+
+	"gvisor.dev/gvisor/pkg/tcpip/link/fdbased"
+
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
+)
+
+func open(u *Unix, offset int) (device.Device, error) {
+	ep, err := fdbased.New(&fdbased.Options{
+		FDs: []int{u.fd},
+		MTU: u.mtu,
+		// TUN only, ignore ethernet header.
+		EthernetHeader: false,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create endpoint: %w", err)
+	}
+	u.LinkEndpoint = ep
+
+	return u, nil
+}

--- a/core/device/unixbase/open_others.go
+++ b/core/device/unixbase/open_others.go
@@ -1,0 +1,21 @@
+//go:build !(linux && amd64) && !(linux && arm64) && !windows
+
+package unixbase
+
+import (
+	"fmt"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
+	"github.com/xjasonlyu/tun2socks/v2/core/device/iobased"
+	"os"
+)
+
+func open(u *Unix, offset int) (device.Device, error) {
+
+	ep, err := iobased.New(os.NewFile(uintptr(u.fd), u.Fd()), u.mtu, offset)
+	if err != nil {
+		return nil, fmt.Errorf("create endpoint: %w", err)
+	}
+	u.LinkEndpoint = ep
+
+	return u, nil
+}

--- a/core/device/unixbase/unixsocket.go
+++ b/core/device/unixbase/unixsocket.go
@@ -1,0 +1,3 @@
+package unixbase
+
+const Driver = "unix"

--- a/core/device/unixbase/unixsocket_unix.go
+++ b/core/device/unixbase/unixsocket_unix.go
@@ -1,0 +1,85 @@
+//go:build !windows
+
+package unixbase
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strconv"
+
+	"golang.org/x/sys/unix"
+	"gvisor.dev/gvisor/pkg/tcpip/stack"
+
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
+)
+
+type Unix struct {
+	stack.LinkEndpoint
+	path string
+	fd   int
+	mtu  uint32
+}
+
+/*
+for example:
+device: unix:///tmp/unix_socket
+*/
+
+func unix2Fd(path string) (int, error) {
+	conn, err := net.Dial("unix", path)
+	if err != nil {
+		return 0, fmt.Errorf("unix socket [%s] connection error: %v", path, conn)
+	}
+
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return 0, errors.New("unexpected")
+	}
+
+	fd, err := unixConn.File()
+	if err != nil {
+		return 0, errors.New("unexpected")
+	}
+
+	return int(fd.Fd()), nil
+}
+
+const defaultMTU = 1500
+
+func Open(path string, mtu uint32, offset int) (device.Device, error) {
+	fd, err := unix2Fd(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if mtu == 0 {
+		mtu = defaultMTU
+	}
+
+	f := &Unix{
+		fd:   fd,
+		path: path,
+		mtu:  mtu,
+	}
+
+	return open(f, offset)
+}
+
+func (f *Unix) Type() string {
+	return Driver
+}
+
+func (f *Unix) Name() string {
+	return f.path
+}
+
+func (f *Unix) Fd() string {
+	return strconv.Itoa(f.fd)
+}
+
+func (f *Unix) Close() error {
+	return unix.Close(f.fd)
+}
+
+var _ device.Device = (*Unix)(nil)

--- a/core/device/unixbase/unixsocket_windows.go
+++ b/core/device/unixbase/unixsocket_windows.go
@@ -1,0 +1,10 @@
+package unixbase
+
+import (
+	"errors"
+	"github.com/xjasonlyu/tun2socks/v2/core/device"
+)
+
+func Open(name string, mtu uint32, offset int) (device.Device, error) {
+	return nil, errors.ErrUnsupported
+}

--- a/engine/parse.go
+++ b/engine/parse.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"encoding/base64"
 	"fmt"
+	"github.com/xjasonlyu/tun2socks/v2/core/device/unixbase"
 	"net"
 	"net/url"
 	"strings"
@@ -58,6 +59,8 @@ func parseDevice(s string, mtu uint32) (device.Device, error) {
 		return parseFD(u, mtu)
 	case tun.Driver:
 		return parseTUN(u, mtu)
+	case unixbase.Driver:
+		return parseUnix(u, mtu)
 	default:
 		return nil, fmt.Errorf("unsupported driver: %s", driver)
 	}
@@ -65,6 +68,10 @@ func parseDevice(s string, mtu uint32) (device.Device, error) {
 
 func parseFD(u *url.URL, mtu uint32) (device.Device, error) {
 	return fdbased.Open(u.Host, mtu, 0)
+}
+
+func parseUnix(u *url.URL, mtu uint32) (device.Device, error) {
+	return unixbase.Open(u.Host, mtu, 0)
 }
 
 func parseProxy(s string) (proxy.Proxy, error) {

--- a/engine/parse.go
+++ b/engine/parse.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/xjasonlyu/tun2socks/v2/core/device/unixbase"
 	"net"
 	"net/url"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/xjasonlyu/tun2socks/v2/core/device"
 	"github.com/xjasonlyu/tun2socks/v2/core/device/fdbased"
 	"github.com/xjasonlyu/tun2socks/v2/core/device/tun"
+	"github.com/xjasonlyu/tun2socks/v2/core/device/unixbase"
 	"github.com/xjasonlyu/tun2socks/v2/proxy"
 	"github.com/xjasonlyu/tun2socks/v2/proxy/proto"
 )


### PR DESCRIPTION
Using FD is compatible with all Linux communication, and I optimized it to use Unix sockets directly，It has no effect on the original method
`device: unix:///tmp/unix_socket`
