### PR TITLE
Optimize the memory footprint under SOCKS5 when USERNAME/PASSWORD authentication is used

### DIFF
--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -16,7 +16,7 @@ type AuthMethod = uint8
 
 // SOCKS authentication methods as defined in RFC 1928 section 3.
 const (
-	MethodNoAuth                  = 0x00
+	MethodNoAuth       AuthMethod = 0x00
 	MethodGSSAPI       AuthMethod = 0x01
 	MethodUserPass     AuthMethod = 0x02
 	MethodNoAcceptable AuthMethod = 0xff

--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -16,10 +16,8 @@ type AuthMethod = uint8
 
 // SOCKS authentication methods as defined in RFC 1928 section 3.
 const (
-	MethodNoAuth       AuthMethod = 0x00
-	MethodGSSAPI       AuthMethod = 0x01
-	MethodUserPass     AuthMethod = 0x02
-	MethodNoAcceptable AuthMethod = 0xff
+	MethodNoAuth   AuthMethod = 0x00
+	MethodUserPass AuthMethod = 0x02
 )
 
 // Version is the protocol version as defined in RFC 1928 section 4.

--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -16,8 +16,10 @@ type AuthMethod = uint8
 
 // SOCKS authentication methods as defined in RFC 1928 section 3.
 const (
-	AuthNo               AuthMethod = 0x00
-	AuthUsernamePassword AuthMethod = 0x02
+	MethodNoAuth                  = 0x00
+	MethodGSSAPI       AuthMethod = 0x01
+	MethodUserPass     AuthMethod = 0x02
+	MethodNoAcceptable AuthMethod = 0xff
 )
 
 // Version is the protocol version as defined in RFC 1928 section 4.
@@ -171,9 +173,9 @@ func ClientHandshake(rw io.ReadWriter, addr Addr, command Command, user *User) (
 
 	var method uint8
 	if user != nil {
-		method = AuthUsernamePassword /* USERNAME/PASSWORD */
+		method = MethodUserPass /* USERNAME/PASSWORD */
 	} else {
-		method = AuthNo /* NO AUTHENTICATION REQUIRED */
+		method = MethodNoAuth /* NO AUTHENTICATION REQUIRED */
 	}
 
 	// VER, NMETHODS, METHODS
@@ -190,7 +192,7 @@ func ClientHandshake(rw io.ReadWriter, addr Addr, command Command, user *User) (
 		return nil, errors.New("socks version mismatched")
 	}
 
-	if buf[1] == AuthUsernamePassword /* USERNAME/PASSWORD */ {
+	if buf[1] == MethodUserPass /* USERNAME/PASSWORD */ {
 		if user == nil {
 			return nil, errors.New("auth required")
 		}
@@ -220,7 +222,7 @@ func ClientHandshake(rw io.ReadWriter, addr Addr, command Command, user *User) (
 			return nil, errors.New("rejected username/password")
 		}
 
-	} else if buf[1] != AuthNo /* NO AUTHENTICATION REQUIRED */ {
+	} else if buf[1] != MethodNoAuth /* NO AUTHENTICATION REQUIRED */ {
 		return nil, errors.New("unsupported method")
 	}
 

--- a/transport/socks5/socks5.go
+++ b/transport/socks5/socks5.go
@@ -11,6 +11,15 @@ import (
 	"strconv"
 )
 
+// AuthMethod is the authentication method as defined in RFC 1928 section 3.
+type AuthMethod = uint8
+
+// SOCKS authentication methods as defined in RFC 1928 section 3.
+const (
+	AuthNo               AuthMethod = 0x00
+	AuthUsernamePassword AuthMethod = 0x02
+)
+
 // Version is the protocol version as defined in RFC 1928 section 4.
 const Version = 0x05
 
@@ -162,9 +171,9 @@ func ClientHandshake(rw io.ReadWriter, addr Addr, command Command, user *User) (
 
 	var method uint8
 	if user != nil {
-		method = 0x02 /* USERNAME/PASSWORD */
+		method = AuthUsernamePassword /* USERNAME/PASSWORD */
 	} else {
-		method = 0x00 /* NO AUTHENTICATION REQUIRED */
+		method = AuthNo /* NO AUTHENTICATION REQUIRED */
 	}
 
 	// VER, NMETHODS, METHODS
@@ -181,22 +190,23 @@ func ClientHandshake(rw io.ReadWriter, addr Addr, command Command, user *User) (
 		return nil, errors.New("socks version mismatched")
 	}
 
-	if buf[1] == 0x02 /* USERNAME/PASSWORD */ {
+	if buf[1] == AuthUsernamePassword /* USERNAME/PASSWORD */ {
 		if user == nil {
 			return nil, errors.New("auth required")
 		}
 
+		authMsgLen := 1 + 1 + len(user.Username) + 1 + len(user.Password)
+		if authMsgLen > MaxAuthLen {
+			return nil, errors.New("auth message too long")
+		}
+
 		// password protocol version
-		authMsg := &bytes.Buffer{}
+		authMsg := bytes.NewBuffer(make([]byte, 0, authMsgLen))
 		authMsg.WriteByte(0x01 /* VER */)
 		authMsg.WriteByte(byte(len(user.Username)) /* ULEN */)
 		authMsg.WriteString(user.Username /* UNAME */)
 		authMsg.WriteByte(byte(len(user.Password)) /* PLEN */)
 		authMsg.WriteString(user.Password /* PASSWD */)
-
-		if len(authMsg.Bytes()) > MaxAuthLen {
-			return nil, errors.New("auth message too long")
-		}
 
 		if _, err := rw.Write(authMsg.Bytes()); err != nil {
 			return nil, err
@@ -210,7 +220,7 @@ func ClientHandshake(rw io.ReadWriter, addr Addr, command Command, user *User) (
 			return nil, errors.New("rejected username/password")
 		}
 
-	} else if buf[1] != 0x00 /* NO AUTHENTICATION REQUIRED */ {
+	} else if buf[1] != AuthNo /* NO AUTHENTICATION REQUIRED */ {
 		return nil, errors.New("unsupported method")
 	}
 

--- a/transport/socks5/socks5_test.go
+++ b/transport/socks5/socks5_test.go
@@ -1,0 +1,32 @@
+package socks5
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSocks5ClientHandshake(t *testing.T) {
+	// Mock server responses
+	readBuffer := &bytes.Buffer{}
+	readBuffer.Write([]byte{Version, AuthUsernamePassword})
+	readBuffer.Write([]byte{Version, 0x00 /* STATUS of SUCCESS */})
+	readBuffer.Write([]byte{Version, 0x00 /* STATUS of SUCCESS */, 0x00 /* RSV */})
+	readBuffer.Write([]byte{AtypIPv4, 0x1, 0x2, 0x3, 0x4, 0x0, 0x0 /* IPv4: 1.2.3.4:0 */})
+	reader := bufio.NewReader(bytes.NewReader(readBuffer.Bytes()))
+
+	writeBuffer := &bytes.Buffer{}
+	writer := bufio.NewWriter(writeBuffer)
+
+	io := bufio.NewReadWriter(reader, writer)
+
+	addr, err := ClientHandshake(io, []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, CmdConnect, &User{
+		Username: "test",
+		Password: "6ab49d8b-a009-44e4-bd53-fbdb48fbe7eb",
+	})
+
+	assert.Nil(t, err, "Failed to perform SOCKS5 client handshake: %v", err)
+	assert.Equal(t, "1.2.3.4:0", addr.String(), "Incorrect address obtained from SOCKS5 client handshake")
+}

--- a/transport/socks5/socks5_test.go
+++ b/transport/socks5/socks5_test.go
@@ -11,7 +11,7 @@ import (
 func TestSocks5ClientHandshake(t *testing.T) {
 	// Mock server responses
 	readBuffer := &bytes.Buffer{}
-	readBuffer.Write([]byte{Version, AuthUsernamePassword})
+	readBuffer.Write([]byte{Version, MethodUserPass})
 	readBuffer.Write([]byte{Version, 0x00 /* STATUS of SUCCESS */})
 	readBuffer.Write([]byte{Version, 0x00 /* STATUS of SUCCESS */, 0x00 /* RSV */})
 	readBuffer.Write([]byte{AtypIPv4, 0x1, 0x2, 0x3, 0x4, 0x0, 0x0 /* IPv4: 1.2.3.4:0 */})


### PR DESCRIPTION
Currently the Go `bytes.Buffer` struct is not used optimally, ref: https://github.com/cty123/tun2socks/blob/main/transport/socks5/socks5.go#L190

```go
authMsg := &bytes.Buffer{}
authMsg.WriteByte(0x01 /* VER */)
authMsg.WriteByte(byte(len(user.Username)) /* ULEN */)
authMsg.WriteString(user.Username /* UNAME */)
authMsg.WriteByte(byte(len(user.Password)) /* PLEN */)
authMsg.WriteString(user.Password /* PASSWD */)
```

`bytes.Buffer{}` always returns an empty buffer with capacity = 0, and this capacity grows as data is written into the buffer. Under the hood, `bytes.Buffer{}` has a priavte `grow(int)` function to allocate additional space to store the data.

```go
func (b *Buffer) Write(p []byte) (n int, err error) {
	b.lastRead = opInvalid
	m, ok := b.tryGrowByReslice(len(p))
	if !ok {
		m = b.grow(len(p))
	}
	return copy(b.buf[m:], p), nil
}

...

func (b *Buffer) grow(n int) int {
	m := b.Len()
	// If buffer is empty, reset to recover space.
	if m == 0 && b.off != 0 {
		b.Reset()
	}
	// Try to grow by means of a reslice.
	if i, ok := b.tryGrowByReslice(n); ok {
		return i
	}
	if b.buf == nil && n <= smallBufferSize {
		b.buf = make([]byte, n, smallBufferSize)
		return 0
	}
	c := cap(b.buf)
...
```

Therefore, during the operation to construct the AuthMsg payload, there are 2 things that are not optimal,

1. The buffer can grow multiple times as we are gradually putting more data into it, eg. username, password.
2. The capacity could be very large compared with the actual data we are storing. 


What we can do instead is that, since the total amount of payload size can be calculated before the allocation, we can compute it and allocate a block of memory that fits exactly to the payload data, such that we are not wasting any memory and can avoid resizing the buffer during the handling. 

For example,

```go
package main

import (
	"bytes"
	"fmt"
)

func main() {
	username := "a very very very very very very very very very very very long username"
	password := "a very very very very very very very very very very very long password"

	fmt.Println("before")

	var authMsg *bytes.Buffer

	authMsg = &bytes.Buffer{}
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteByte(0x01 /* VER */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteByte(byte(len(username)) /* ULEN */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteString(username /* UNAME */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteByte(byte(len(password)) /* PLEN */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteString(password /* PASSWD */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	// cap: 0 len: 0
	// cap: 64 len: 1
	// cap: 64 len: 2
	// cap: 128 len: 72
	// cap: 128 len: 73
	// cap: 256 len: 143

	fmt.Println("after")

	authMsgLen := 1 + 1 + len(username) + 1 + len(password)
	authMsg = bytes.NewBuffer(make([]byte, 0, authMsgLen))
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteByte(0x01 /* VER */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteByte(byte(len(username)) /* ULEN */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteString(username /* UNAME */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteByte(byte(len(password)) /* PLEN */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	authMsg.WriteString(password /* PASSWD */)
	fmt.Println("cap:", authMsg.Cap(), "len:", authMsg.Len())

	// cap: 143 len: 0
	// cap: 143 len: 1
	// cap: 143 len: 2
	// cap: 143 len: 72
	// cap: 143 len: 73
	// cap: 143 len: 143
}
```