### PR TITLE
Add make for loong64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ UNIX_ARCH_LIST = \
 	linux-ppc64 \
 	linux-ppc64le \
 	linux-s390x \
+	linux-loong64 \
 	openbsd-amd64 \
 	openbsd-amd64-v3 \
 	openbsd-arm64
@@ -128,6 +129,9 @@ linux-ppc64le:
 
 linux-s390x:
 	GOARCH=s390x GOOS=linux $(GO_BUILD) -o $(BUILD_DIR)/$(BINARY)-$@
+
+linux-loong64:
+	GOARCH=loong64 GOOS=linux $(GO_BUILD) -o $(BUILD_DIR)/$(BINARY)-$@
 
 openbsd-amd64:
 	GOARCH=amd64 GOOS=openbsd $(GO_BUILD) -o $(BUILD_DIR)/$(BINARY)-$@


### PR DESCRIPTION
add [loong64](https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN) build to Makefile