### PR TITLE
Feature(socks5): support abstract namespace unix sock

### DIFF
--- a/proxy/socks5.go
+++ b/proxy/socks5.go
@@ -26,6 +26,13 @@ type Socks5 struct {
 }
 
 func NewSocks5(addr, user, pass string) (*Socks5, error) {
+	unix := len(addr) > 0 && addr[0] == '/'
+
+	// For support Linux abstract namespace
+	if len(addr) > 2 && addr[1] == '@' || addr[1] == 0x00 {
+		addr = addr[1:]
+	}
+
 	return &Socks5{
 		Base: &Base{
 			addr:  addr,
@@ -33,7 +40,7 @@ func NewSocks5(addr, user, pass string) (*Socks5, error) {
 		},
 		user: user,
 		pass: pass,
-		unix: len(addr) > 0 && addr[0] == '/',
+		unix: unix,
 	}, nil
 }
 


### PR DESCRIPTION
> On Linux, if the name starts with an at symbol (‘@') it is read as an abstract namespace socket: the leading ‘@' is replaced with a NUL byte before binding or connecting.  For details, see unix(7)

In golang, we can add `@` or use `0x0` as prefix to the unix addr for using Linux abstract namespace.
But the current unix processing logic can't not parse it, it only supports the filesystem socket type.
This PR should fix this.