### PR TITLE
Feature: add an option to disable UDP

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -132,6 +132,10 @@ func general(k *Key) error {
 		}
 		tunnel.T().SetUDPTimeout(k.UDPTimeout)
 	}
+
+	if k.UDPDisabled {
+		tunnel.T().SetUDPDisabled(true)
+	}
 	return nil
 }
 

--- a/engine/key.go
+++ b/engine/key.go
@@ -17,4 +17,5 @@ type Key struct {
 	TUNPreUp                 string        `yaml:"tun-pre-up"`
 	TUNPostUp                string        `yaml:"tun-post-up"`
 	UDPTimeout               time.Duration `yaml:"udp-timeout"`
+	UDPDisabled              bool          `yaml:"udp-disabled"`
 }

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func init() {
 	flag.IntVar(&key.Mark, "fwmark", 0, "Set firewall MARK (Linux only)")
 	flag.IntVar(&key.MTU, "mtu", 0, "Set device maximum transmission unit (MTU)")
 	flag.DurationVar(&key.UDPTimeout, "udp-timeout", 0, "Set timeout for each UDP session")
+	flag.BoolVar(&key.UDPDisabled, "udp-disabled", false, "Disable UDP")
 	flag.StringVar(&configFile, "config", "", "YAML format configuration file")
 	flag.StringVar(&key.Device, "device", "", "Use this device [driver://]name")
 	flag.StringVar(&key.Interface, "interface", "", "Use network INTERFACE (Linux/MacOS only)")

--- a/proxy/socks5.go
+++ b/proxy/socks5.go
@@ -26,6 +26,13 @@ type Socks5 struct {
 }
 
 func NewSocks5(addr, user, pass string) (*Socks5, error) {
+	unix := len(addr) > 0 && addr[0] == '/'
+
+	// For support Linux abstract namespace
+	if len(addr) > 2 && addr[1] == '@' || addr[1] == 0x00 {
+		addr = addr[1:]
+	}
+
 	return &Socks5{
 		Base: &Base{
 			addr:  addr,
@@ -33,7 +40,7 @@ func NewSocks5(addr, user, pass string) (*Socks5, error) {
 		},
 		user: user,
 		pass: pass,
-		unix: len(addr) > 0 && addr[0] == '/',
+		unix: unix,
 	}, nil
 }
 

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -31,6 +31,9 @@ type Tunnel struct {
 	// UDP session timeout.
 	udpTimeout *atomic.Duration
 
+	// UDP disabled flag.
+	udpDisabled *atomic.Bool
+
 	// Internal proxy.Dialer for Tunnel.
 	dialerMu sync.RWMutex
 	dialer   proxy.Dialer
@@ -44,12 +47,13 @@ type Tunnel struct {
 
 func New(dialer proxy.Dialer, manager *statistic.Manager) *Tunnel {
 	return &Tunnel{
-		tcpQueue:   make(chan adapter.TCPConn),
-		udpQueue:   make(chan adapter.UDPConn),
-		udpTimeout: atomic.NewDuration(udpSessionTimeout),
-		dialer:     dialer,
-		manager:    manager,
-		procCancel: func() { /* nop */ },
+		tcpQueue:    make(chan adapter.TCPConn),
+		udpQueue:    make(chan adapter.UDPConn),
+		udpTimeout:  atomic.NewDuration(udpSessionTimeout),
+		udpDisabled: atomic.NewBool(false),
+		dialer:      dialer,
+		manager:     manager,
+		procCancel:  func() { /* nop */ },
 	}
 }
 
@@ -113,4 +117,8 @@ func (t *Tunnel) SetDialer(dialer proxy.Dialer) {
 
 func (t *Tunnel) SetUDPTimeout(timeout time.Duration) {
 	t.udpTimeout.Store(timeout)
+}
+
+func (t *Tunnel) SetUDPDisabled(disabled bool) {
+	t.udpDisabled.Store(disabled)
 }

--- a/tunnel/udp.go
+++ b/tunnel/udp.go
@@ -17,6 +17,11 @@ import (
 func (t *Tunnel) handleUDPConn(uc adapter.UDPConn) {
 	defer uc.Close()
 
+	if t.udpDisabled.Load() {
+		log.Warnf("[UDP] dial %s: blocked", uc.ID().RemoteAddress)
+		return
+	}
+
 	id := uc.ID()
 	metadata := &M.Metadata{
 		Network: M.UDP,


### PR DESCRIPTION
Some proxy server may not support udp, the udp processing logic may slow down performance, we can explicitly disable it before letting program to detect if the proxy server supports it.

NOTE: I done this in my own branch, it may including the commits from the previous PR, you may cherrypick it as you need.