### PR TITLE
Fix crash on multiple start/stop due to FD being closed twice

### DIFF
--- a/core/device/fdbased/fd_unix.go
+++ b/core/device/fdbased/fd_unix.go
@@ -17,8 +17,9 @@ const defaultMTU = 1500
 type FD struct {
 	stack.LinkEndpoint
 
-	fd  int
-	mtu uint32
+	fd     int
+	mtu    uint32
+	closed bool
 }
 
 func Open(name string, mtu uint32, offset int) (device.Device, error) {
@@ -41,8 +42,11 @@ func (f *FD) Name() string {
 }
 
 func (f *FD) Close() {
-	defer f.LinkEndpoint.Close()
-	_ = unix.Close(f.fd)
+	if !f.closed {
+		defer f.LinkEndpoint.Close()
+		_ = unix.Close(f.fd)
+		f.closed = true
+	}
 }
 
 var _ device.Device = (*FD)(nil)


### PR DESCRIPTION
On Android, when calling start() and stop() multiple times in a VPN application using tun2socks, the program crashes with:

    fdsan: attempted to close file descriptor XXX, expected to be unowned, actually owned by unique_fd ...

This happens because both `_defaultDevice.Close()` and `_defaultStack.Wait()`, which are called inside `stop()`, attempt to close the same file descriptor. The issue was observed when using ParcelFileDescriptor from VpnService, where the FD is detached and passed to the tun2socks engine.
