### PR TITLE
CI: use `gogost/gost:latest` for SSH proxy tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
             proxy: ss://aes-128-gcm:pass@192.168.1.2:8388
             udp: true
           - protocol: SSH
-            image: gogost/gost:3.0.0-nightly.20241002
+            image: gogost/gost:latest
             args: -L "sshd://user:pass@:2222"
             proxy: ssh://user:pass@192.168.1.2:2222
             udp: false


### PR DESCRIPTION
A gost ssh proxy related issue was fixed in: https://github.com/go-gost/x/pull/79.

Related issue: https://github.com/go-gost/x/issues/78